### PR TITLE
Fix color regex

### DIFF
--- a/lib/colorscore/histogram.rb
+++ b/lib/colorscore/histogram.rb
@@ -22,7 +22,7 @@ module Colorscore
 
     # Returns an array of colors in descending order of occurances.
     def colors
-      hex_values = @lines.map { |line| line[/#([0-9A-F]{6}) /, 1] }.compact
+      hex_values = @lines.map { |line| line[/#([0-9A-F]{6})/, 1] }.compact
       hex_values.map { |hex| Color::RGB.from_html(hex) }
     end
 


### PR DESCRIPTION
The space at the end of the regex causes all values to be nil. Removing it fixes the problem.